### PR TITLE
Relying on `msgs` table for searches.

### DIFF
--- a/sortthread.go
+++ b/sortthread.go
@@ -265,7 +265,7 @@ func (m *Mailbox) orderedSubjThread(tx *sql.Tx, uid bool, seqSet *imap.SeqSet, m
 				}
 			}
 
-			next.Id = msg.id
+			next.Id = id
 			current.Children = []*sortthread.Thread{next}
 			current = next
 		}

--- a/sortthread.go
+++ b/sortthread.go
@@ -259,7 +259,7 @@ func (m *Mailbox) orderedSubjThread(tx *sql.Tx, uid bool, seqSet *imap.SeqSet, m
 			id := msg.id
 			if !uid {
 				var ok bool
-				id, ok = m.handle.UidAsSeq(id)
+				_, ok = m.handle.UidAsSeq(id)
 				if !ok {
 					continue // Wtf
 				}

--- a/sql_search.go
+++ b/sql_search.go
@@ -9,16 +9,17 @@ import (
 func buildSearchStmt(withFlags, withoutFlags []string) string {
 	var stmt string
 	stmt += `
-		SELECT DISTINCT flags.msgId
-		FROM flags
-		WHERE mboxId = ?
+		SELECT DISTINCT msgs.msgId
+		FROM msgs
+		LEFT JOIN flags ON msgs.msgId = flags.msgid
+		WHERE msgs.mboxId = ?
 		`
 
 	if len(withFlags) != 0 {
 		if len(withFlags) == 1 {
-			stmt += `AND flag = ? `
+			stmt += `AND flags.flag = ? `
 		} else {
-			stmt += `AND flag IN (`
+			stmt += `AND flags.flag IN (`
 			for i := range withFlags {
 				stmt += `?`
 				if i != len(withFlags)-1 {
@@ -29,7 +30,7 @@ func buildSearchStmt(withFlags, withoutFlags []string) string {
 		}
 	}
 	if len(withoutFlags) != 0 {
-		stmt += `AND flags.msgId NOT IN (` + buildSearchStmt(withoutFlags, nil) + `)`
+		stmt += `AND msgs.msgId NOT IN (` + buildSearchStmt(withoutFlags, nil) + `)`
 	}
 	if len(withFlags) > 1 {
 		stmt += `GROUP BY flags.msgId HAVING COUNT(*) = ` + strconv.Itoa(len(withFlags))


### PR DESCRIPTION
This PR solves the following issue https://github.com/foxcpp/maddy/issues/549 caused by messages created without any flags. 

Emails received by `maddy` directly will always have at least `\Recent` flag but some migration tools may not sync this flag based on [RFC 3501](https://www.rfc-editor.org/rfc/rfc3501#section-2.3.2) statement that says: "This flag can not be altered by the client."