### PR TITLE
Create override imap folders if needed

### DIFF
--- a/delivery.go
+++ b/delivery.go
@@ -96,30 +96,17 @@ func (d *Delivery) Mailbox(name string) error {
 
 	for _, u := range d.users {
 		if mboxName := d.mboxOverrides[u.username]; mboxName != "" {
-			_, mbox, err := u.GetMailbox(mboxName, true, nil)
+			_, mbox, err := u.GetOrCreateMailbox(mboxName, true, nil)
 			if err == nil {
 				d.mboxes = append(d.mboxes, *mbox.(*Mailbox))
 				continue
 			}
 		}
 
-		_, mbox, err := u.GetMailbox(name, true, nil)
+		_, mbox, err := u.GetOrCreateMailbox(name, true, nil)
 		if err != nil {
-			if err != backend.ErrNoSuchMailbox {
-				d.mboxes = nil
-				return err
-			}
-
-			if err := u.CreateMailbox(name); err != nil && err != backend.ErrMailboxAlreadyExists {
-				d.mboxes = nil
-				return err
-			}
-
-			_, mbox, err = u.GetMailbox(name, true, nil)
-			if err != nil {
-				d.mboxes = nil
-				return err
-			}
+			d.mboxes = nil
+			return err
 		}
 
 		d.mboxes = append(d.mboxes, *mbox.(*Mailbox))
@@ -141,7 +128,7 @@ func (d *Delivery) SpecialMailbox(attribute, fallbackName string) error {
 	}
 	for _, u := range d.users {
 		if mboxName := d.mboxOverrides[u.username]; mboxName != "" {
-			_, mbox, err := u.GetMailbox(mboxName, true, nil)
+			_, mbox, err := u.GetOrCreateMailbox(mboxName, true, nil)
 			if err == nil {
 				d.mboxes = append(d.mboxes, *mbox.(*Mailbox))
 				continue

--- a/user.go
+++ b/user.go
@@ -97,6 +97,19 @@ func (u *User) ListMailboxes(subscribed bool) ([]imap.MailboxInfo, error) {
 	return res, nil
 }
 
+func (u *User) GetOrCreateMailbox(name string, readOnly bool, conn backend.Conn) (*imap.MailboxStatus, backend.Mailbox, error) {
+	status, mbox, err := u.GetMailbox(name, readOnly, conn)
+	if err == nil || err != backend.ErrNoSuchMailbox {
+		return status, mbox, err
+	}
+
+	if err := u.CreateMailbox(name); err != nil && err != backend.ErrMailboxAlreadyExists {
+		return nil, nil, err
+	}
+
+	return u.GetMailbox(name, readOnly, conn)
+}
+
 func (u *User) GetMailbox(name string, readOnly bool, conn backend.Conn) (*imap.MailboxStatus, backend.Mailbox, error) {
 	var mbox *Mailbox
 


### PR DESCRIPTION
The delivery allows for user overrides to affect the destination imap folder.  The function documentation indicates that if the destination folder does not exist, it will be created.  However, the creation function only works for explicitly set folders, not for the overrides.

This change creates a simple `GetOrCreate` user call for an imap folder. It then leverages this call both in the original non-override path as well as the override path.